### PR TITLE
Configurable SMTP support; We can now specify host, port, user, password, and whether or not to use SSL.

### DIFF
--- a/pinball/config/default.yaml
+++ b/pinball/config/default.yaml
@@ -98,3 +98,10 @@ authentication_domains:                     []
 # aes_cbc_key:
 # hmac_key:
 # crypto_version:
+
+# SMTP Settings
+# smtp_host:    default_value = localhost
+# smtp_port:    default_value = 25, change to 465 if smtp_ssl is True 
+# smtp_user:    default_value = ''
+# smtp_pass:    default_value = ''
+# smtp_ssl:     default_value = False

--- a/pinball/config/pinball_config.py
+++ b/pinball/config/pinball_config.py
@@ -169,6 +169,13 @@ class PinballConfig(object):
 
     ALLOWED_HOSTS = ['*']
 
+    # SMTP Configuration
+    SMTP_HOST = 'localhost'
+    SMTP_PORT = 25
+    SMTP_USER = ''
+    SMTP_PASS = ''
+    SMTP_SSL  = False
+
     @staticmethod
     def parse(config_file):
         # Assume the config file is "yaml" file

--- a/pinball/run_pinball.py
+++ b/pinball/run_pinball.py
@@ -183,7 +183,7 @@ def main():
         master_name(PinballConfig.MASTER_NAME)
     _pinball_imports()
     if PinballConfig.UI_HOST:
-        emailer = Emailer(PinballConfig.UI_HOST, 80)
+        emailer = Emailer(PinballConfig.UI_HOST, PinballConfig.UI_PORT)
     else:
         emailer = Emailer(socket.gethostname(), PinballConfig.UI_PORT)
 
@@ -211,7 +211,7 @@ def main():
     else:
         assert options.mode == 'workers'
         if PinballConfig.UI_HOST:
-            emailer = Emailer(PinballConfig.UI_HOST, 80)
+            emailer = Emailer(PinballConfig.UI_HOST, PinballConfig.UI_PORT)
         else:
             emailer = Emailer(socket.gethostname(), PinballConfig.UI_PORT)
         threads = _create_workers(PinballConfig.WORKERS, factory, emailer)

--- a/pinball/workflow/emailer.py
+++ b/pinball/workflow/emailer.py
@@ -64,8 +64,16 @@ class Emailer(object):
         if html_part:
             msg.attach(html_part)
 
-        # Send the message via local SMTP server.
-        smtp = smtplib.SMTP('localhost')
+        # Send the message via configurable SMTP server.
+        if PinballConfig.SMTP_SSL:
+            smtp = smtplib.SMTP_SSL(PinballConfig.SMTP_HOST, PinballConfig.SMTP_PORT)
+        else:
+            smtp = smtplib.SMTP(PinballConfig.SMTP_HOST, PinballConfig.SMTP_PORT)
+
+        # Authorization: Login/Password
+        if PinballConfig.SMTP_USER:
+            smtp.login(PinballConfig.SMTP_USER, PinballConfig.SMTP_PASS)
+
         smtp.sendmail(msg['From'], to, msg.as_string())
         smtp.quit()
         LOG.info('Sent email to %s with subject "%s"', msg['To'], subject)


### PR DESCRIPTION
Hi everyone,

This may be helpful. It allows someone to specify smtp settings in the config.yaml. For example, I have put my sendgrid credentials and I am also specifying SSL via: smtp_ssl: True.

Also there was one potential bug. When I received emails, all of the links were broken. This was due to the hardcoded port 80 in pinball/run_pinball.py. I changed that to use UI_PORT and now everything is working as I "think" it should; all of the links work.

If you have any questions or concerns regarding the PR, please let me know.

Thanks!