### PR TITLE
Replace typographer's quotes with normal ones to avoid Python SyntaxErro...

### DIFF
--- a/tutorial/example_repo/workflows.py
+++ b/tutorial/example_repo/workflows.py
@@ -53,8 +53,8 @@ WORKFLOWS = {
     # E.g., printing PINBALL:EVENT_ATTR:akey=avalue to the job output will embed a
     # akey-avalue pair in the job output event. Output events traverse along job
     # output edges and they are accessible by downstream jobs. Event attributes are
-    # used to customize the job command line. E.g., command “echo %(akey)s” will be
-    # translated to “echo avalue” by the job executor.
+    # used to customize the job command line. E.g., command "echo %(akey)s" will be
+    # translated to "echo avalue" by the job executor.
     'pass_params_between_jobs': WorkflowConfig(
         jobs={
             'cmd_parent': JobConfig(CommandJobTemplate('ExamplePinballMagicCMD',


### PR DESCRIPTION
Will you accept this pull request that changes typographer's quotes to regular ones? This solves a syntax error on my system.

```shell
PYTHONPATH=. python -m pinball.tools.workflow_util -c $CONFIG_PATH -f reschedule

...
SyntaxError: Non-ASCII character '\xe2' in file tutorial/example_repo/workflows.py on line 56, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
...
```