### PR TITLE
Passed allowed_hosts parameter

### DIFF
--- a/pinball/config/utils.py
+++ b/pinball/config/utils.py
@@ -187,6 +187,7 @@ def token_to_str(token):
 
 def set_django_environment():
     settings.configure(DEBUG=PinballConfig.DEBUG,
+                       ALLOWED_HOSTS=PinballConfig.ALLOWED_HOSTS,
                        SECRET_KEY=PinballConfig.SECRET_KEY,
                        INSTALLED_APPS=PinballConfig.INSTALLED_APPS,
                        MIDDLEWARE_CLASSES=PinballConfig.MIDDLEWARE_CLASSES,


### PR DESCRIPTION
Hey guys,

If PinballConfig.DEBUG is enabled, the django always return 5xx code. It's known issue. Here's a stackoverflow thread.

- https://github.com/pinterest/pinball/blob/master/pinball/config/default.yaml#L11
- http://stackoverflow.com/questions/15128135/setting-debug-false-causes-500-error

![image](https://cloud.githubusercontent.com/assets/1086275/8930188/b29d585c-3566-11e5-9613-a9cfc37b87c5.png)