### PR TITLE
fix build as pydot is not available anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "2.7"
 
 install:
-  - "pip install --allow-unverified pydot pydot==1.0.28"
   - "pip install -r requirements.txt"
 
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ MySQL-python==1.2.3
 nose==1.3.4
 oauth2client==1.2
 pycrypto==2.6
-pydot==1.0.28
+pydot2==1.0.33
 python-dateutil==1.5
 PyTrie==0.1
 pytz==2013b


### PR DESCRIPTION
Change the pydot version to 1.0.33, so the build can work again.
the original pydot repo was hosted on googlecode which is not available anymore.