### PR TITLE
Pass workflow / instance / job / execution to the job from Pinball.

### DIFF
--- a/pinball/workflow/job_executor.py
+++ b/pinball/workflow/job_executor.py
@@ -509,6 +509,17 @@ class ShellJobExecutor(JobExecutor):
                     # Pinball sets Django module path which may interfere
                     # with the command being executed.
                     env.pop('DJANGO_SETTINGS_MODULE', None)
+
+                    # Pass workflow/instance/job/execution to the job.
+                    # This will be consumed by Dr. Elephant.
+                    env['PINBALL_WORKFLOW'] = self._workflow
+                    env['PINBALL_INSTANCE'] = self._instance
+                    env['PINBALL_JOB'] = self._job_name
+                    env['PINBALL_EXECUTION'] = str(len(self.job.history) - 1)
+
+                    if PinballConfig.UI_HOST is not None:
+                        env['PINBALL_BASE_URL'] = PinballConfig.UI_HOST
+
                     # The os.setsid() is passed in the argument preexec_fn
                     # so it's run after the fork() and before  exec() to
                     # run the shell.  It attaches a session id of the child

--- a/tests/pinball/workflow/job_executor_test.py
+++ b/tests/pinball/workflow/job_executor_test.py
@@ -220,6 +220,63 @@ class ShellJobExecutorTestCase(unittest.TestCase):
 
         self.assertEqual(2, get_s3_key_mock.call_count)
 
+    @mock.patch('pinball.workflow.log_saver.S3FileLogSaver._get_or_create_s3_key')
+    @mock.patch('os.path.exists')
+    @mock.patch('__builtin__.open')
+    def test_execute_env_var(self, rm_mock, open_mock, exists_mock, get_s3_key_mock):
+        file_mock = mock.MagicMock()
+        open_mock.return_value = file_mock
+        file_mock.__enter__.return_value = file_mock
+
+        s3_key_mock = mock.MagicMock()
+        get_s3_key_mock.return_value = s3_key_mock
+        s3_key_mock.__enter__.return_value = s3_key_mock
+
+        job_name = 'some_job'
+        workflow_name = 'some_workflow'
+        instance = '123'
+
+        job = ShellJob(name=job_name,
+                       command="echo $PINBALL_WORKFLOW && "
+                               "echo $PINBALL_JOB && "
+                               "echo $PINBALL_INSTANCE && "
+                               "echo $PINBALL_EXECUTION && "
+                               "echo $PINBALL_BASE_URL",
+                       emails=['some_email@pinterest.com'],
+                       warn_timeout_sec=10,
+                       abort_timeout_sec=20)
+        executor = ShellJobExecutor(workflow_name, instance, job_name,
+                                    job, self._data_builder,
+                                    self._emailer)
+
+        import time
+        execution_record = ExecutionRecord(instance=instance,
+                                           start_time=time.time())
+        execution_record.end_time = time.time()
+        execution_record.exit_code = 1
+        job.history.append(execution_record)
+
+        self.assertTrue(executor.prepare())
+        self.assertTrue(executor.execute())
+
+        file_mock.write.assert_has_calls(
+            [mock.call(workflow_name + '\n'),
+             mock.call(job_name + '\n'),
+             mock.call(instance + '\n'),
+             mock.call('1\n')])
+
+        exists_mock.assert_any_call(
+            '/tmp/pinball/logs/' + workflow_name + '/' + instance)
+
+        # stdout and stderr
+        self.assertEqual(rm_mock.call_count, 3)
+
+        self.assertEqual(2, len(executor.job.history))
+        execution_record = executor.job.history[1]
+        self.assertEqual(0, execution_record.exit_code)
+
+        self.assertEqual(3, get_s3_key_mock.call_count)
+
     def test_process_log_line(self):
         job = ShellJob(name='some_job',
                        command="echo ok",


### PR DESCRIPTION
Unable to run tests:  

ERROR: invocation failed (exit code 1), logfile: /Users/anshulp/code/pinball-fork/.tox/py27/log/py27-1.log
ERROR: actionid: py27
msg: getenv
cmdargs: ['/Users/anshulp/code/pinball-fork/.tox/py27/bin/pip', 'install', '-r/Users/anshulp/code/pinball-fork/requirements.txt', 'pytest']
env: {'LANG': 'en_US.UTF-8', 'USERNAME': 'root', 'TERM': 'xterm-256color', 'SHELL': '/bin/sh', 'SUDO_COMMAND': '/Users/anshulp/code/pinball-fork/pinb/bin/tox', 'VERSIONER_PYTHON_PREFER_32_BIT': 'no', 'SUDO_UID': '0', 'SUDO_GID': '0', 'SSH_AUTH_SOCK': '/private/tmp/com.apple.launchd.5wLh1KPp79/Listeners', 'VIRTUAL_ENV': '/Users/anshulp/code/pinball-fork/.tox/py27', '__CF_USER_TEXT_ENCODING': '0x0:0:0', 'PYTHONHASHSEED': '197297078', 'LOGNAME': 'root', 'USER': 'root', 'MAIL': '/var/mail/root', 'PATH': '/Users/anshulp/code/pinball-fork/.tox/py27/bin:/Users/anshulp/code/pinball-fork/pinb/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/anshulp/arcanist/arcanist/bin', 'SUDO_USER': 'root', 'PS1': '(pinb) [\\T]\\[\\e[0;32m\\] \\w\\[\\e[0;36m\\]$(print_symlink)\\[\\e[0;31m\\]$(parse_git_branch)\\[\\e[0m\\] $ ', 'HOME': '/var/root', 'VERSIONER_PYTHON_VERSION': '2.7'}

Collecting pytest
  Using cached pytest-3.0.3-py2.py3-none-any.whl
Collecting argparse==1.2.1 (from -r /Users/anshulp/code/pinball-fork/requirements.txt (line 1))
  Using cached argparse-1.2.1.tar.gz
Collecting boto==2.8.0 (from -r /Users/anshulp/code/pinball-fork/requirements.txt (line 2))
  Using cached boto-2.8.0.tar.gz
Collecting Django==1.5.4 (from -r /Users/anshulp/code/pinball-fork/requirements.txt (line 3))
  Using cached Django-1.5.4.tar.gz
Collecting guppy==0.1.10 (from -r /Users/anshulp/code/pinball-fork/requirements.txt (line 4))
  Using cached guppy-0.1.10.tar.gz
Collecting mock==0.8.0 (from -r /Users/anshulp/code/pinball-fork/requirements.txt (line 5))
  Using cached mock-0.8.0.zip
Collecting MySQL-python==1.2.3 (from -r /Users/anshulp/code/pinball-fork/requirements.txt (line 6))
  Using cached MySQL-python-1.2.3.tar.gz
    Complete output from command python setup.py egg_info:
    sh: mysql_config: command not found
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/tmp/pip-build-tmgGwy/MySQL-python/setup.py", line 15, in <module>
        metadata, options = get_config()
      File "setup_posix.py", line 43, in get_config
        libs = mysql_config("libs_r")
      File "setup_posix.py", line 24, in mysql_config
        raise EnvironmentError("%s not found" % (mysql_config.path,))
    EnvironmentError: mysql_config not found
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/tmp/pip-build-tmgGwy/MySQL-python/

ERROR: could not install deps [-r/Users/anshulp/code/pinball-fork/requirements.txt, pytest]; v = InvocationError('/Users/anshulp/code/pinball-fork/.tox/py27/bin/pip install -r/Users/anshulp/code/pinball-fork/requirements.txt pytest (see /Users/anshulp/code/pinball-fork/.tox/py27/log/py27-1.log)', 1)
_________________________________________________________ summary __________________________________________________________
ERROR:   py27: could not install deps [-r/Users/anshulp/code/pinball-fork/requirements.txt, pytest]; v = InvocationError('/Users/anshulp/code/pinball-fork/.tox/py27/bin/pip install -r/Users/anshulp/code/pinball-fork/requirements.txt pytest (see /Users/anshulp/code/pinball-fork/.tox/py27/log/py27-1.log)', 1)