### PR TITLE
Fix incorrect "no master at ..." when running on separate host

### DIFF
--- a/pinball/ui/views.py
+++ b/pinball/ui/views.py
@@ -304,7 +304,7 @@ class TokenView(TokenPathsView):
 def _is_master_alive():
     try:
         s = socket.socket()
-        host = 'localhost'
+        host = PinballConfig.MASTER_HOST
         s.connect((host, PinballConfig.MASTER_PORT))
         s.close()
     except:
@@ -325,7 +325,7 @@ def status(request):
         elif data_builder.is_signal_set(workflow, instance, Signal.DRAIN):
             status = ['draining']
         if not _is_master_alive():
-            status.append('no master at %s:%d' % (socket.gethostname(),
+            status.append('no master at %s:%d' % (PinballConfig.MASTER_HOST,
                                                   PinballConfig.MASTER_PORT))
         status_json = json.dumps(status)
     except:


### PR DESCRIPTION
The `_is_master_alive` function was only checking `localhost` instead of using the `MASTER_HOST` value, which was incorrect if running on separate hosts