### PR TITLE
Use secure random number generator in get_random_string

### DIFF
--- a/pinball_ext/common/utils.py
+++ b/pinball_ext/common/utils.py
@@ -19,6 +19,12 @@ import random
 import string
 
 
+try:
+    random = random.SystemRandom()
+except NotImplementedError:
+    logging.getLogger(__name__).error('No system level randomness available. PRNG in software is not secure.')
+
+
 __author__ = 'Changshu Liu'
 __copyright__ = 'Copyright 2015, Pinterest, Inc.'
 __credits__ = [__author__]


### PR DESCRIPTION
get_random_string is used for creating hard to guess file names and the default PRNG is predictable. This replaces the PRNG with a secure random number generator when available.